### PR TITLE
Fix undefined variable in `bin/release`

### DIFF
--- a/bin/release
+++ b/bin/release
@@ -1,3 +1,4 @@
 #!/bin/sh
 
+BUILD_DIR="${1}"
 echo "agent: sensu-agent start --log-level=debug" > $BUILD_DIR/Procfile


### PR DESCRIPTION
Previously the `bin/release` script was silently failing, since `$BUILD_DIR` is not defined. The build directory instead has to be retrieved from the first argument passed to `bin/release`:
https://devcenter.heroku.com/articles/buildpack-api#bin-release

This issue not only means the `bin/release` script does not write `Procfile` as expected, but also means it exits non-zero. 

Currently the Heroku build system ignores non-zero `bin/release` exit codes, however this is due to change in the future, at which point builds using this buildpack will fail without this fix.